### PR TITLE
Fix WTSINFOEX struct for accurate session info

### DIFF
--- a/KeyboardBacklightForLenovo.Service/ResetOrchestrator.cs
+++ b/KeyboardBacklightForLenovo.Service/ResetOrchestrator.cs
@@ -1,62 +1,62 @@
 ﻿namespace KeyboardBacklightForLenovo
 {
-    public sealed class ResetOrchestrator
+  public sealed class ResetOrchestrator
+  {
+    private readonly SessionWatcher _sessions;
+    private DateTime _lastReset = DateTime.MinValue;
+
+    public ResetOrchestrator(SessionWatcher sessions) => _sessions = sessions;
+
+    public async Task TryResetIfNoUserAsync(string reason, TimeSpan waitForUserSession = default)
     {
-        private readonly SessionWatcher _sessions;
-        private DateTime _lastReset = DateTime.MinValue;
-
-        public ResetOrchestrator(SessionWatcher sessions) => _sessions = sessions;
-
-        public async Task TryResetIfNoUserAsync(string reason, TimeSpan waitForUserSession = default)
+      try
+      {
+        // Optional: wait briefly for a session to appear if requested
+        if (waitForUserSession > TimeSpan.Zero)
         {
-            try
+          var deadline = DateTime.UtcNow + waitForUserSession;
+          var delay = TimeSpan.FromMilliseconds(500);
+          while (DateTime.UtcNow < deadline)
+          {
+            if (_sessions.IsAnyUserLoggedOn(reason))
             {
-                // Optional: wait briefly for a session to appear if requested
-                if (waitForUserSession > TimeSpan.Zero)
-                {
-                    var deadline = DateTime.UtcNow + waitForUserSession;
-                    var delay = TimeSpan.FromMilliseconds(500);
-                    while (DateTime.UtcNow < deadline)
-                    {
-                        if (_sessions.IsAnyUserLoggedOn())
-                        {
-                            ServiceLogger.LogInfo($"[{reason}] User logged on (after wait) -> skip.");
-                            return;
-                        }
-                        await Task.Delay(delay);
-                        // Exponential backoff up to 5s between checks
-                        if (delay < TimeSpan.FromSeconds(5)) delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 5000));
-                    }
-                }
-
-                if (_sessions.IsAnyUserLoggedOn())
-                {
-                    ServiceLogger.LogInfo($"[{reason}] User logged on -> skip.");
-                    return;
-                }
-
-                ServiceLogger.LogInfo($"[{reason}] No logged-on user detected.");
-
-                // Avoid duplicate application within bursts of 1001
-                if ((DateTime.UtcNow - _lastReset) < TimeSpan.FromSeconds(1))
-                    return;
-
-                var preferred = PreferredLevelStore.ReadPreferredLevel();
-                ServiceLogger.LogInfo($"[{reason}] No user session. Preferred={preferred}. Applying reset...");
-
-                using var ctrl = new KeyboardBacklightController();
-                int status = PreferredLevelStore.ReadPreferredLevel();
-                ctrl.ResetStatus(status);
-
-                _lastReset = DateTime.UtcNow;
-                ServiceLogger.LogInfo($"[{reason}] Reset applied successfully.");
+              ServiceLogger.LogInfo($"[{reason}] User logged on (after wait) -> skip.");
+              return;
             }
-            catch (Exception ex)
-            {
-                ServiceLogger.LogError($"[{reason}] Reset failed: {ex}");
-            }
-
-            await Task.CompletedTask;
+            await Task.Delay(delay);
+            // Exponential backoff up to 5s between checks
+            if (delay < TimeSpan.FromSeconds(5)) delay = TimeSpan.FromMilliseconds(Math.Min(delay.TotalMilliseconds * 2, 5000));
+          }
         }
+
+        if (_sessions.IsAnyUserLoggedOn(reason))
+        {
+          ServiceLogger.LogInfo($"[{reason}] User logged on -> skip.");
+          return;
+        }
+
+        ServiceLogger.LogInfo($"[{reason}] No logged-on user detected.");
+
+        // Avoid duplicate application within bursts of 1001
+        if ((DateTime.UtcNow - _lastReset) < TimeSpan.FromSeconds(1))
+          return;
+
+        var preferred = PreferredLevelStore.ReadPreferredLevel();
+        ServiceLogger.LogInfo($"[{reason}] No user session. Preferred={preferred}. Applying reset...");
+
+        using var ctrl = new KeyboardBacklightController();
+        int status = PreferredLevelStore.ReadPreferredLevel();
+        ctrl.ResetStatus(status);
+
+        _lastReset = DateTime.UtcNow;
+        ServiceLogger.LogInfo($"[{reason}] Reset applied successfully.");
+      }
+      catch (Exception ex)
+      {
+        ServiceLogger.LogError($"[{reason}] Reset failed: {ex}");
+      }
+
+      await Task.CompletedTask;
     }
+  }
 }

--- a/KeyboardBacklightForLenovo.Service/SessionWatcher.cs
+++ b/KeyboardBacklightForLenovo.Service/SessionWatcher.cs
@@ -105,5 +105,36 @@ namespace KeyboardBacklightForLenovo
             WTSDomainName = 7,
             WTSSessionInfoEx = 24
         }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct WTSINFOEX
+        {
+            public int Level;
+            public WTSINFOEX_LEVEL1 Data;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        public struct WTSINFOEX_LEVEL1
+        {
+            public int SessionId;
+            public WTS_CONNECTSTATE_CLASS SessionState;
+            public int SessionFlags;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 33)]
+            public string WinStationName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 21)]
+            public string UserName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 18)]
+            public string DomainName;
+
+            public long LogonTime;
+            public long ConnectTime;
+            public long DisconnectTime;
+            public long LastInputTime;
+            public long CurrentTime;
+            public long TimeZoneBias;
+        }
     }
 }

--- a/KeyboardBacklightForLenovo.Service/SessionWatcher.cs
+++ b/KeyboardBacklightForLenovo.Service/SessionWatcher.cs
@@ -2,139 +2,142 @@
 
 namespace KeyboardBacklightForLenovo
 {
-    public sealed class SessionWatcher
+  public sealed class SessionWatcher
+  {
+    /// <summary>
+    /// True if there is any HUMAN user logged on (locked or unlocked).
+    /// Definition: any session with SessionId != 0 that has a non-empty user name
+    /// not belonging to built-in service/system accounts (SYSTEM, LOCAL/NETWORK SERVICE,
+    /// DWM-*, UMFD-*, defaultuser0), and in WTSActive state.
+    /// </summary>
+    public bool IsAnyUserLoggedOn(string reason)
     {
-        /// <summary>
-        /// True if there is any HUMAN user logged on (locked or unlocked).
-        /// Definition: any session with SessionId != 0 that has a non-empty user name
-        /// not belonging to built-in service/system accounts (SYSTEM, LOCAL/NETWORK SERVICE,
-        /// DWM-*, UMFD-*, defaultuser0), and in WTSActive state.
-        /// </summary>
-        public bool IsAnyUserLoggedOn()
+      if (!WtsApi32.WTSEnumerateSessions(IntPtr.Zero, 0, 1, out var pp, out var count))
+        return false;
+
+      try
+      {
+        var size = Marshal.SizeOf<WtsApi32.WTS_SESSION_INFO>();
+        for (int i = 0; i < count; i++)
         {
-            if (!WtsApi32.WTSEnumerateSessions(IntPtr.Zero, 0, 1, out var pp, out var count))
-                return false;
+          var p = pp + i * size;
+          var info = Marshal.PtrToStructure<WtsApi32.WTS_SESSION_INFO>(p);
 
-            try
-            {
-                var size = Marshal.SizeOf<WtsApi32.WTS_SESSION_INFO>();
-                for (int i = 0; i < count; i++)
-                {
-                    var p = pp + i * size;
-                    var info = Marshal.PtrToStructure<WtsApi32.WTS_SESSION_INFO>(p);
+          // Exclude Session 0 (services), it's never a human session.
+          if (info.SessionId == 0)
+            continue;
 
-                    // Exclude Session 0 (services), it's never a human session.
-                    if (info.SessionId == 0)
-                        continue;
+          // Consider a human user present only when the session is active.
+          // This avoids false positives from disconnected/idle sessions during boot.
+          if (info.State != WtsApi32.WTS_CONNECTSTATE_CLASS.WTSActive)
+            continue;
 
-                    // Consider a human user present only when the session is active.
-                    // This avoids false positives from disconnected/idle sessions during boot.
-                    if (info.State != WtsApi32.WTS_CONNECTSTATE_CLASS.WTSActive)
-                        continue;
-
-                    var user = WtsApi32.WTSQuerySessionString(IntPtr.Zero, info.SessionId, WtsApi32.WTS_INFO_CLASS.WTSUserName);
-                    var domain = WtsApi32.WTSQuerySessionString(IntPtr.Zero, info.SessionId, WtsApi32.WTS_INFO_CLASS.WTSDomainName);
-                    if (!string.IsNullOrWhiteSpace(user) && !IsServiceOrSystemUser(user))
-                        return true;
-                }
-            }
-            finally
-            {
-                WtsApi32.WTSFreeMemory(pp);
-            }
-
-            return false;
+          var user = WtsApi32.WTSQuerySessionString(IntPtr.Zero, info.SessionId, WtsApi32.WTS_INFO_CLASS.WTSUserName);
+          var domain = WtsApi32.WTSQuerySessionString(IntPtr.Zero, info.SessionId, WtsApi32.WTS_INFO_CLASS.WTSDomainName);
+          if (!string.IsNullOrWhiteSpace(user) && !IsServiceOrSystemUser(user))
+          {
+            ServiceLogger.LogInfo($"[{reason}] {user} logged on.");
+            return true;
+          }
         }
+      }
+      finally
+      {
+        WtsApi32.WTSFreeMemory(pp);
+      }
 
-        private static bool IsServiceOrSystemUser(string user)
-        {
-            // Fast filter for built-in accounts we never treat as "interactive".
-            return user.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase)
-                || user.Equals("LOCAL SERVICE", StringComparison.OrdinalIgnoreCase)
-                || user.Equals("NETWORK SERVICE", StringComparison.OrdinalIgnoreCase)
-                || user.Equals("defaultuser0", StringComparison.OrdinalIgnoreCase)
-                || user.StartsWith("DWM-", StringComparison.OrdinalIgnoreCase)
-                || user.StartsWith("UMFD-", StringComparison.OrdinalIgnoreCase);
-        }
+      return false;
     }
 
-    internal static class WtsApi32
+    private static bool IsServiceOrSystemUser(string user)
     {
-        [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
-        public static extern bool WTSEnumerateSessions(IntPtr hServer, int Reserved, int Version, out IntPtr ppSessionInfo, out int pCount);
-
-        [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
-        public static extern void WTSFreeMemory(IntPtr pMemory);
-
-        [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
-        public static extern bool WTSQuerySessionInformation(IntPtr hServer, int SessionId, WTS_INFO_CLASS WTSInfoClass, out IntPtr ppBuffer, out int pBytesReturned);
-
-        public static string WTSQuerySessionString(IntPtr server, int sessionId, WTS_INFO_CLASS cls)
-        {
-            if (!WTSQuerySessionInformation(server, sessionId, cls, out var p, out _))
-                return string.Empty;
-            try { return Marshal.PtrToStringUni(p) ?? string.Empty; }
-            finally { WTSFreeMemory(p); }
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct WTS_SESSION_INFO
-        {
-            public int SessionId;
-            public IntPtr pWinStationName;
-            public WTS_CONNECTSTATE_CLASS State;
-        }
-
-        public enum WTS_CONNECTSTATE_CLASS
-        {
-            WTSActive,
-            WTSConnected,
-            WTSConnectQuery,
-            WTSShadow,
-            WTSDisconnected,
-            WTSIdle,
-            WTSListen,
-            WTSReset,
-            WTSDown,
-            WTSInit
-        }
-
-        public enum WTS_INFO_CLASS
-        {
-            WTSUserName = 5,
-            WTSDomainName = 7,
-            WTSSessionInfoEx = 24
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public struct WTSINFOEX
-        {
-            public int Level;
-            public WTSINFOEX_LEVEL1 Data;
-        }
-
-        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
-        public struct WTSINFOEX_LEVEL1
-        {
-            public int SessionId;
-            public WTS_CONNECTSTATE_CLASS SessionState;
-            public int SessionFlags;
-
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 33)]
-            public string WinStationName;
-
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 21)]
-            public string UserName;
-
-            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 18)]
-            public string DomainName;
-
-            public long LogonTime;
-            public long ConnectTime;
-            public long DisconnectTime;
-            public long LastInputTime;
-            public long CurrentTime;
-            public long TimeZoneBias;
-        }
+      // Fast filter for built-in accounts we never treat as "interactive".
+      return user.Equals("SYSTEM", StringComparison.OrdinalIgnoreCase)
+          || user.Equals("LOCAL SERVICE", StringComparison.OrdinalIgnoreCase)
+          || user.Equals("NETWORK SERVICE", StringComparison.OrdinalIgnoreCase)
+          || user.Equals("defaultuser0", StringComparison.OrdinalIgnoreCase)
+          || user.StartsWith("DWM-", StringComparison.OrdinalIgnoreCase)
+          || user.StartsWith("UMFD-", StringComparison.OrdinalIgnoreCase);
     }
+  }
+
+  internal static class WtsApi32
+  {
+    [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
+    public static extern bool WTSEnumerateSessions(IntPtr hServer, int Reserved, int Version, out IntPtr ppSessionInfo, out int pCount);
+
+    [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
+    public static extern void WTSFreeMemory(IntPtr pMemory);
+
+    [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
+    public static extern bool WTSQuerySessionInformation(IntPtr hServer, int SessionId, WTS_INFO_CLASS WTSInfoClass, out IntPtr ppBuffer, out int pBytesReturned);
+
+    public static string WTSQuerySessionString(IntPtr server, int sessionId, WTS_INFO_CLASS cls)
+    {
+      if (!WTSQuerySessionInformation(server, sessionId, cls, out var p, out _))
+        return string.Empty;
+      try { return Marshal.PtrToStringUni(p) ?? string.Empty; }
+      finally { WTSFreeMemory(p); }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct WTS_SESSION_INFO
+    {
+      public int SessionId;
+      public IntPtr pWinStationName;
+      public WTS_CONNECTSTATE_CLASS State;
+    }
+
+    public enum WTS_CONNECTSTATE_CLASS
+    {
+      WTSActive,
+      WTSConnected,
+      WTSConnectQuery,
+      WTSShadow,
+      WTSDisconnected,
+      WTSIdle,
+      WTSListen,
+      WTSReset,
+      WTSDown,
+      WTSInit
+    }
+
+    public enum WTS_INFO_CLASS
+    {
+      WTSUserName = 5,
+      WTSDomainName = 7,
+      WTSSessionInfoEx = 24
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct WTSINFOEX
+    {
+      public int Level;
+      public WTSINFOEX_LEVEL1 Data;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct WTSINFOEX_LEVEL1
+    {
+      public int SessionId;
+      public WTS_CONNECTSTATE_CLASS SessionState;
+      public int SessionFlags;
+
+      [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 33)]
+      public string WinStationName;
+
+      [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 21)]
+      public string UserName;
+
+      [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 18)]
+      public string DomainName;
+
+      public long LogonTime;
+      public long ConnectTime;
+      public long DisconnectTime;
+      public long LastInputTime;
+      public long CurrentTime;
+      public long TimeZoneBias;
+    }
+  }
 }

--- a/KeyboardBacklightForLenovo.Service/SessionWatcher.cs
+++ b/KeyboardBacklightForLenovo.Service/SessionWatcher.cs
@@ -60,13 +60,13 @@ namespace KeyboardBacklightForLenovo
 
     internal static class WtsApi32
     {
-        [DllImport("Wtsapi32.dll")]
+        [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
         public static extern bool WTSEnumerateSessions(IntPtr hServer, int Reserved, int Version, out IntPtr ppSessionInfo, out int pCount);
 
-        [DllImport("Wtsapi32.dll")]
+        [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
         public static extern void WTSFreeMemory(IntPtr pMemory);
 
-        [DllImport("Wtsapi32.dll")]
+        [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
         public static extern bool WTSQuerySessionInformation(IntPtr hServer, int SessionId, WTS_INFO_CLASS WTSInfoClass, out IntPtr ppBuffer, out int pBytesReturned);
 
         public static string WTSQuerySessionString(IntPtr server, int sessionId, WTS_INFO_CLASS cls)

--- a/KeyboardBacklightForLenovo.Service/WorkstationLock.cs
+++ b/KeyboardBacklightForLenovo.Service/WorkstationLock.cs
@@ -50,10 +50,10 @@ namespace KeyboardBacklightForLenovo
         // Minimal interop needed for WTSSessionInfoEx
         private static class WtsNative
         {
-            [DllImport("Wtsapi32.dll")]
+            [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
             public static extern bool WTSQuerySessionInformation(IntPtr hServer, int SessionId, WTS_INFO_CLASS WTSInfoClass, out IntPtr ppBuffer, out int pBytesReturned);
 
-            [DllImport("Wtsapi32.dll")]
+            [DllImport("Wtsapi32.dll", CharSet = CharSet.Unicode)]
             public static extern void WTSFreeMemory(IntPtr pMemory);
 
             [DllImport("Kernel32.dll")]


### PR DESCRIPTION
## Summary
- remove unused `Reserved` field from `WTSINFOEX`
- correct `WinStationName`, `UserName`, and `DomainName` array sizes
- apply `StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)` to `WTSINFOEX` level structures

## Testing
- `dotnet build KeyboardBacklightForLenovo.Service/KeyboardBacklightForLenovo.Service.csproj -c Release`
- `dotnet build -c Release` *(fails: powershell: not found; Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b6f3884c832f9314951ca35eb18d