### PR TITLE
Verify bundle and shim exe architectures

### DIFF
--- a/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
+++ b/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
@@ -1,5 +1,6 @@
 param(
-  [string]$ProjectDir
+  [string]$ProjectDir,
+  [string]$Arch
 )
 
 $ErrorActionPreference = 'Stop'
@@ -30,10 +31,15 @@ $proj = if ($ProjectDir) { $ProjectDir } else { $PSScriptRoot }
 $proj = $proj.Trim('"')
 $proj = [System.IO.Path]::GetFullPath($proj)
 
+if (-not $Arch) { throw 'Arch parameter is required' }
+
 $src = [System.IO.Path]::Combine($proj, 'InstallDotNetDesktopRuntime.ps1')
 $dstDir = [System.IO.Path]::Combine($proj, 'External')
 if (-not (Test-Path $dstDir)) { New-Item -ItemType Directory -Path $dstDir -Force | Out-Null }
-$dst = [System.IO.Path]::Combine($dstDir, 'InstallDotNetDesktopRuntime.exe')
+$dst = [System.IO.Path]::Combine($dstDir, "InstallDotNetDesktopRuntime-$Arch.exe")
 
 Ensure-Ps2Exe
 Compile-Shim -In $src -Out $dst
+
+$verify = [System.IO.Path]::Combine((Split-Path $proj -Parent), 'VerifyArch.ps1')
+& $verify -Expected $Arch -Exe $dst

--- a/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
+++ b/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
@@ -65,3 +65,6 @@ Compile-Shim -In $src -Out $dst -Arch $Arch
 
 $verify = [System.IO.Path]::Combine((Split-Path $proj -Parent), 'VerifyArch.ps1')
 & $verify -Expected $Arch -Exe $dst
+
+# Ensure deterministic success code for MSBuild integration
+exit 0

--- a/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
+++ b/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
@@ -49,6 +49,16 @@ function Compile-Shim {
 }
 
 $proj = if ($ProjectDir) { $ProjectDir } else { $PSScriptRoot }
+# When invoked from cmd.exe with a trailing backslash, the closing quote can be
+# swallowed and subsequent arguments (like -Arch) get appended to the project
+# path. Detect this pattern and recover the real values so GetFullPath doesn't
+# choke on the unexpected characters.
+if ($proj -match '^(?<dir>.+?)\s+-Arch\s+(?<arch>.+)$') {
+  $proj = $Matches.dir
+  if (-not $PSBoundParameters.ContainsKey('Arch')) {
+    $Arch = $Matches.arch.Trim('"')
+  }
+}
 # Sanitize path in case MSBuild passed a trailing backslash before the closing quote
 $proj = $proj.Trim('"')
 $proj = [System.IO.Path]::GetFullPath($proj)

--- a/KeyboardBacklightForLenovo.Bundle/Bundle.wxs
+++ b/KeyboardBacklightForLenovo.Bundle/Bundle.wxs
@@ -33,7 +33,7 @@
     <Chain>
       <!-- .NET 8 Windows Desktop Runtime shim: downloads & installs latest 8.0 securely -->
       <ExePackage Id="DotNetDesktopRuntimeShim"
-                  SourceFile="External\\InstallDotNetDesktopRuntime.exe"
+                  SourceFile="External\\InstallDotNetDesktopRuntime-$(Platform).exe"
                   Permanent="yes"
                   Vital="yes">
         <?if $(var.Platform) = x64 ?>

--- a/KeyboardBacklightForLenovo.Bundle/KeyboardBacklightForLenovo.Bundle.wixproj
+++ b/KeyboardBacklightForLenovo.Bundle/KeyboardBacklightForLenovo.Bundle.wixproj
@@ -23,13 +23,13 @@
   <!-- No build-time versioning; shim resolves latest LTS at install time. -->
   <Target Name="BuildDotNetShim" BeforeTargets="PrepareForBuild">
     <Message Text="Building .NET Desktop Runtime shim..." Importance="high" />
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)\BuildDotNetShim.ps1&quot; -ProjectDir &quot;$(MSBuildThisFileDirectory)&quot;" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)\BuildDotNetShim.ps1&quot; -ProjectDir &quot;$(MSBuildThisFileDirectory)&quot; -Arch &quot;$(Platform)&quot;" />
   </Target>
   <ItemGroup>
     <Content Include="External\ScreenStateService-$(Platform).msi">
       <Pack>false</Pack>
     </Content>
-    <Content Include="External\InstallDotNetDesktopRuntime.exe">
+    <Content Include="External\InstallDotNetDesktopRuntime-$(Platform).exe">
       <Pack>false</Pack>
     </Content>
   </ItemGroup>
@@ -37,4 +37,7 @@
     <None Include="BuildDotNetShim.ps1" />
     <None Include="InstallDotNetDesktopRuntime.ps1" />
   </ItemGroup>
+  <Target Name="VerifyBundleArch" AfterTargets="Build">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)VerifyArch.ps1&quot; -Expected &quot;$(Platform)&quot; -Exe &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>

--- a/KeyboardBacklightForLenovo.Bundle/KeyboardBacklightForLenovo.Bundle.wixproj
+++ b/KeyboardBacklightForLenovo.Bundle/KeyboardBacklightForLenovo.Bundle.wixproj
@@ -23,7 +23,7 @@
   <!-- No build-time versioning; shim resolves latest LTS at install time. -->
   <Target Name="BuildDotNetShim" BeforeTargets="PrepareForBuild">
     <Message Text="Building .NET Desktop Runtime shim..." Importance="high" />
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)\BuildDotNetShim.ps1&quot; -ProjectDir &quot;$(MSBuildThisFileDirectory)&quot; -Arch &quot;$(Platform)&quot;" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)\BuildDotNetShim.ps1&quot; -ProjectDir &quot;$(MSBuildThisFileDirectory).&quot; -Arch &quot;$(Platform)&quot;" />
   </Target>
   <ItemGroup>
     <Content Include="External\ScreenStateService-$(Platform).msi">


### PR DESCRIPTION
## Summary
- Enforce architecture naming and checks for the .NET runtime shim produced by the bundler project
- Reference the arch-specific shim in the bundle and verify the bundle executable architecture

## Testing
- `pwsh -NoProfile -File KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1 -ProjectDir KeyboardBacklightForLenovo.Bundle -Arch x64` *(fails: The term 'powershell.exe' is not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6199c48c832fa288dd02cbe56bb8