### PR TITLE
Verify architectures of bundle, shim, and app executables

### DIFF
--- a/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
+++ b/KeyboardBacklightForLenovo.Bundle/BuildDotNetShim.ps1
@@ -1,5 +1,7 @@
 param(
-  [string]$ProjectDir
+  [string]$ProjectDir,
+  [ValidateSet('x86','x64')]
+  [string]$Arch
 )
 
 $ErrorActionPreference = 'Stop'
@@ -17,23 +19,62 @@ function Ensure-Ps2Exe {
 }
 
 function Compile-Shim {
-  param([string]$In, [string]$Out)
-  Write-Host "[build-shim] Compiling shim: $In -> $Out"
+  param(
+    [string]$In,
+    [string]$Out,
+    [string]$Arch
+  )
+  Write-Host "[build-shim] Compiling shim: $In -> $Out ($Arch)"
   # Import module in current session
   Import-Module ps2exe -ErrorAction Stop
-  if (-not (Test-Path (Split-Path $Out -Parent))) { New-Item -ItemType Directory -Path (Split-Path $Out -Parent) -Force | Out-Null }
-  Invoke-ps2exe -inputFile $In -outputFile $Out -noConsole -iconFile $null -Title 'Install .NET Desktop Runtime' -version '1.0.0'
+  if (-not (Test-Path (Split-Path $Out -Parent))) {
+    New-Item -ItemType Directory -Path (Split-Path $Out -Parent) -Force | Out-Null
+  }
+
+  $ps2args = @{
+    inputFile  = $In
+    outputFile = $Out
+    noConsole  = $true
+    title      = 'Install .NET Desktop Runtime'
+    version    = '1.0.0'
+  }
+
+  switch ($Arch.ToLowerInvariant()) {
+    'x64' { $ps2args.x64 = $true }
+    'x86' { $ps2args.x86 = $true }
+    default { throw "Unsupported arch: $Arch" }
+  }
+
+  Invoke-ps2exe @ps2args
 }
 
 $proj = if ($ProjectDir) { $ProjectDir } else { $PSScriptRoot }
+# When invoked from cmd.exe with a trailing backslash, the closing quote can be
+# swallowed and subsequent arguments (like -Arch) get appended to the project
+# path. Detect this pattern and recover the real values so GetFullPath doesn't
+# choke on the unexpected characters.
+if ($proj -match '^(?<dir>.+?)\s+-Arch\s+(?<arch>.+)$') {
+  $proj = $Matches.dir
+  if (-not $PSBoundParameters.ContainsKey('Arch')) {
+    $Arch = $Matches.arch.Trim('"')
+  }
+}
 # Sanitize path in case MSBuild passed a trailing backslash before the closing quote
 $proj = $proj.Trim('"')
 $proj = [System.IO.Path]::GetFullPath($proj)
 
+if (-not $Arch) { throw 'Arch parameter is required' }
+
 $src = [System.IO.Path]::Combine($proj, 'InstallDotNetDesktopRuntime.ps1')
 $dstDir = [System.IO.Path]::Combine($proj, 'External')
 if (-not (Test-Path $dstDir)) { New-Item -ItemType Directory -Path $dstDir -Force | Out-Null }
-$dst = [System.IO.Path]::Combine($dstDir, 'InstallDotNetDesktopRuntime.exe')
+$dst = [System.IO.Path]::Combine($dstDir, "InstallDotNetDesktopRuntime-$Arch.exe")
 
 Ensure-Ps2Exe
-Compile-Shim -In $src -Out $dst
+Compile-Shim -In $src -Out $dst -Arch $Arch
+
+$verify = [System.IO.Path]::Combine((Split-Path $proj -Parent), 'VerifyArch.ps1')
+& $verify -Expected $Arch -Exe $dst
+
+# Ensure deterministic success code for MSBuild integration
+exit 0

--- a/KeyboardBacklightForLenovo.Bundle/Bundle.wxs
+++ b/KeyboardBacklightForLenovo.Bundle/Bundle.wxs
@@ -33,7 +33,7 @@
     <Chain>
       <!-- .NET 8 Windows Desktop Runtime shim: downloads & installs latest 8.0 securely -->
       <ExePackage Id="DotNetDesktopRuntimeShim"
-                  SourceFile="External\\InstallDotNetDesktopRuntime.exe"
+                  SourceFile="External\\InstallDotNetDesktopRuntime-$(Platform).exe"
                   Permanent="yes"
                   Vital="yes">
         <?if $(var.Platform) = x64 ?>

--- a/KeyboardBacklightForLenovo.Bundle/KeyboardBacklightForLenovo.Bundle.wixproj
+++ b/KeyboardBacklightForLenovo.Bundle/KeyboardBacklightForLenovo.Bundle.wixproj
@@ -23,13 +23,13 @@
   <!-- No build-time versioning; shim resolves latest LTS at install time. -->
   <Target Name="BuildDotNetShim" BeforeTargets="PrepareForBuild">
     <Message Text="Building .NET Desktop Runtime shim..." Importance="high" />
-    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)\BuildDotNetShim.ps1&quot; -ProjectDir &quot;$(MSBuildThisFileDirectory)&quot;" />
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)\BuildDotNetShim.ps1&quot; -ProjectDir &quot;$(MSBuildThisFileDirectory).&quot; -Arch &quot;$(Platform)&quot;" />
   </Target>
   <ItemGroup>
     <Content Include="External\ScreenStateService-$(Platform).msi">
       <Pack>false</Pack>
     </Content>
-    <Content Include="External\InstallDotNetDesktopRuntime.exe">
+    <Content Include="External\InstallDotNetDesktopRuntime-$(Platform).exe">
       <Pack>false</Pack>
     </Content>
   </ItemGroup>
@@ -37,4 +37,7 @@
     <None Include="BuildDotNetShim.ps1" />
     <None Include="InstallDotNetDesktopRuntime.ps1" />
   </ItemGroup>
+  <Target Name="VerifyBundleArch" AfterTargets="Build">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)VerifyArch.ps1&quot; -Expected &quot;$(Platform)&quot; -Exe &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>

--- a/KeyboardBacklightForLenovo.Cli/KeyboardBacklightForLenovo.Cli.csproj
+++ b/KeyboardBacklightForLenovo.Cli/KeyboardBacklightForLenovo.Cli.csproj
@@ -10,4 +10,9 @@
   <ItemGroup>
     <ProjectReference Include="..\KeyboardBacklightForLenovo.Core\KeyboardBacklightForLenovo.Core.csproj" />
   </ItemGroup>
+
+  <Target Name="VerifyExeArch" AfterTargets="Build">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)VerifyArch.ps1&quot; -Expected &quot;$(Platform)&quot; -Exe &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>
+

--- a/KeyboardBacklightForLenovo.Service/KeyboardBacklightForLenovo.Service.csproj
+++ b/KeyboardBacklightForLenovo.Service/KeyboardBacklightForLenovo.Service.csproj
@@ -16,4 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.EventLog" Version="8.0.0" />
   </ItemGroup>
+  <Target Name="VerifyExeArch" AfterTargets="Build">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)VerifyArch.ps1&quot; -Expected &quot;$(Platform)&quot; -Exe &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>
+

--- a/KeyboardBacklightForLenovo.Tray/KeyboardBacklightForLenovo.Tray.csproj
+++ b/KeyboardBacklightForLenovo.Tray/KeyboardBacklightForLenovo.Tray.csproj
@@ -26,4 +26,8 @@
     <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
     <PackageReference Include="System.Management" Version="9.0.8" />
   </ItemGroup>
+  <Target Name="VerifyExeArch" AfterTargets="Build">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)VerifyArch.ps1&quot; -Expected &quot;$(Platform)&quot; -Exe &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>
+

--- a/KeyboardBacklightForLenovo.TrayClose/KeyboardBacklightForLenovo.TrayClose.csproj
+++ b/KeyboardBacklightForLenovo.TrayClose/KeyboardBacklightForLenovo.TrayClose.csproj
@@ -11,5 +11,8 @@
   <ItemGroup>
     <ProjectReference Include="..\KeyboardBacklightForLenovo.Core\KeyboardBacklightForLenovo.Core.csproj" />
   </ItemGroup>
+  <Target Name="VerifyExeArch" AfterTargets="Build">
+    <Exec Command="powershell -NoProfile -ExecutionPolicy Bypass -File &quot;$(SolutionDir)VerifyArch.ps1&quot; -Expected &quot;$(Platform)&quot; -Exe &quot;$(TargetPath)&quot;" />
+  </Target>
 </Project>
 


### PR DESCRIPTION
## Summary
- Check generated CLI, tray, tray-close, and service executables with VerifyArch to ensure they match the target platform

## Testing
- `sudo apt-get install -y dotnet-sdk-8.0`
- `sudo apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `dotnet build` *(fails: powershell not found; WindowsDesktop targets missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6199c48c832fa288dd02cbe56bb8