### PR TITLE
Recognize hardware Auto backlight mode on EnergyDrv

### DIFF
--- a/KeyboardBacklightForLenovo.Cli/Program.cs
+++ b/KeyboardBacklightForLenovo.Cli/Program.cs
@@ -122,6 +122,7 @@ internal static class Program
       0 => "Off",
       1 => "Low",
       2 => "High",
+      3 => "Auto",
       _ => "Unknown"
     };
     Console.WriteLine($"principal={ctrl.Principal} ({ctrl.Description})  mapped={mapped} ({lvl})  store={PreferredLevelStore.StorePath}");

--- a/KeyboardBacklightForLenovo.Core/DriversConfig.json
+++ b/KeyboardBacklightForLenovo.Core/DriversConfig.json
@@ -32,6 +32,7 @@
     "getOff": "0x00010001",
     "getLow": "0x00010003",
     "getHigh": "0x00010005",
+    "getAuto": "0x00010007",
     "setIoctl": "0x83102144",
     "setOff": "0x00000033",
     "setLow": "0x00010033",

--- a/KeyboardBacklightForLenovo.Core/KeyboardBacklightController.cs
+++ b/KeyboardBacklightForLenovo.Core/KeyboardBacklightController.cs
@@ -15,6 +15,7 @@ namespace KeyboardBacklightForLenovo
     public const int LevelOff = 0;
     public const int LevelLow = 1;
     public const int LevelHigh = 2;
+    public const int LevelAuto = 3;
 
     private readonly DriverConfig _driver;
     private readonly SafeFileHandle _handle;
@@ -102,6 +103,7 @@ namespace KeyboardBacklightForLenovo
       if (raw == driver.GetOff) return LevelOff;
       if (raw == driver.GetLow) return LevelLow;
       if (raw == driver.GetHigh) return LevelHigh;
+      if (driver.GetAuto.HasValue && raw == driver.GetAuto.Value) return LevelAuto;
 
       throw new InvalidOperationException($"Unknown GET status value: 0x{raw:X8}");
     }
@@ -196,6 +198,7 @@ namespace KeyboardBacklightForLenovo
           GetOff = ParseU32(j.GetOff, nameof(j.GetOff)),
           GetLow = ParseU32(j.GetLow, nameof(j.GetLow)),
           GetHigh = ParseU32(j.GetHigh, nameof(j.GetHigh)),
+          GetAuto = ParseU32Nullable(j.GetAuto),
           SetOff = ParseU32(j.SetOff, nameof(j.SetOff)),
           SetLow = ParseU32(j.SetLow, nameof(j.SetLow)),
           SetHigh = ParseU32(j.SetHigh, nameof(j.SetHigh)),
@@ -237,6 +240,7 @@ namespace KeyboardBacklightForLenovo
       public string? GetOff { get; set; }
       public string? GetLow { get; set; }
       public string? GetHigh { get; set; }
+      public string? GetAuto { get; set; }
       public string? SetIoctl { get; set; }
       public string? SetOff { get; set; }
       public string? SetLow { get; set; }
@@ -253,6 +257,7 @@ namespace KeyboardBacklightForLenovo
       public uint GetOff { get; set; }
       public uint GetLow { get; set; }
       public uint GetHigh { get; set; }
+      public uint? GetAuto { get; set; }
       public uint SetOff { get; set; }
       public uint SetLow { get; set; }
       public uint SetHigh { get; set; }


### PR DESCRIPTION
When the keyboard is in Lenovo's hardware Auto mode (the default on some ThinkBook/IdeaPad models), EnergyDrv returns 0x00010007 from the GET ioctl. The controller previously had no mapping for that value, fell through to "Unknown GET status value", and the driver-detection loop gave up with "No supported keyboard backlight driver found" -- so the CLI failed and the tray app exited.

Add an optional getAuto entry to DriverConfig and a fourth LevelAuto = 3 so GetStatus can report the state without erroring. The CLI prints "Auto" for level 3. SET behaviour is unchanged; Off/Low/High overrides still apply as before, so existing preferred-level restoration works.

The new field is opt-in: drivers without getAuto behave exactly as before. Populated for the EnergyDrv upper-word variant only, matching the hardware where 0x00010007 was observed.